### PR TITLE
TE-959, Add and configure eslint-plugin-jsdoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = {
     },
     sourceType: 'module',
   },
-  plugins: ['babel', 'import', 'prettier', 'react'],
+  plugins: ['babel', 'import', 'prettier', 'react', 'jsdoc'],
   settings: {
     'import/resolver': {
       'babel-module': {},
@@ -35,6 +35,14 @@ module.exports = {
     'import/no-default-export': 2,
     'import/no-unresolved': [2, importNoUnresolved],
     'import/order': [2, importOrder],
+    'jsdoc/check-param-names': 2,
+    'jsdoc/check-types': 2,
+    'jsdoc/no-undefined-types': 2,
+    'jsdoc/require-param': 2,
+    'jsdoc/require-param-name': 2,
+    'jsdoc/require-param-type': 2,
+    'jsdoc/require-returns-type': 2,
+    'jsdoc/valid-types': 2,
     'padding-line-between-statements': [2, ...paddingLineBetweenStatements],
     'no-console': 2,
     'no-undef': 2,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "access": "public"
   },
   "peerDependencies": {
+    "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
     "babel-plugin-module-resolver": "^3.1.1",
     "eslint": "^4.19.1",
@@ -29,6 +30,7 @@
     "eslint-import-resolver-babel-module": "^4.0.0",
     "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-import": "^2.12.0",
+    "eslint-plugin-jsdoc": "^3.8.0",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.8.2"
   },
@@ -40,6 +42,7 @@
     "eslint-import-resolver-babel-module": "^4.0.0",
     "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-import": "^2.12.0",
+    "eslint-plugin-jsdoc": "^3.8.0",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.8.2",
     "prettier": "^1.12.1",


### PR DESCRIPTION
## What is the one thing this PR does?
Adds npm package `eslint-plugin-jsdocs` and configures it with the following rules: 
[Youtrack Issue](https://youtrack.lodgify.net/agiles/86-18/87-568?issue=TE-959)


```
rules {
    "jsdoc/check-param-names": 2,
    "jsdoc/check-types": 2,
    "jsdoc/no-undefined-types": 2,
    "jsdoc/require-param": 2,
    "jsdoc/require-param-name": 2,
    "jsdoc/require-param-type": 2,
    "jsdoc/require-returns-type": 2,
    "jsdoc/valid-types": 2,
}
```



