### PR TITLE
fix: Solve NPM install warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
-    "babel-plugin-module-resolver": "^3.1.1",
+    "babel-plugin-module-resolver": ">=3.1.1 <= 5",
     "eslint": "^4.19.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-import-resolver-babel-module": "^4.0.0",


### PR DESCRIPTION
Related Youtrack [Issue](https://youtrack.lodgify.net/agiles/86-18/87-1241?p=86-18%2F87-1194&issue=TE-2218)

### What one thing does this PR do

Enhances the version of `babel-plugin-module-resolver` to solve npm warnings in `templates-ssr`.

